### PR TITLE
Revert readme demo link commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A lightweight and extensible JavaScript library for executing **Extract → Transform → Load** pipelines directly in the browser, without a backend.
 
-[![🚀 Live Demo](https://img.shields.io/badge/🚀-Live%20Demo-blue?style=for-the-badge&logo=html5&logoColor=white)](https://browser-etl.github.io/demo)
-
 ## 🚀 Installation
 
 ```bash


### PR DESCRIPTION
Remove the live demo badge from `README.md` as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-602de262-7392-4a1a-bd02-f5d151acbf15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-602de262-7392-4a1a-bd02-f5d151acbf15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

