### PR TITLE
Lancer les tests d'intégration

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import typescript from '@rollup/plugin-typescript';
 import { terser } from 'rollup-plugin-terser';
 import dts from 'rollup-plugin-dts';
 
-const packageJson = require('./package.json');
+import packageJson from './package.json' assert { type: 'json' };
 
 export default [
   {


### PR DESCRIPTION
Update `rollup.config.js` to use ES module import for `package.json` to resolve a `require` in ES module context error.

---
<a href="https://cursor.com/background-agent?bcId=bc-2615f4be-757b-4529-af70-2b272f5e3e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2615f4be-757b-4529-af70-2b272f5e3e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

